### PR TITLE
Support designsafe.storage.frontera.work system

### DIFF
--- a/camino/docker-compose.yml
+++ b/camino/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - /corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
       - /ds-mydata:/ds-mydata
       - /frontera-scratch:/frontera-scratch
+      - /frontera-work:/frontera-work
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     logging:

--- a/server/main.py
+++ b/server/main.py
@@ -35,6 +35,8 @@ def get_system_root(system: str) -> str:
             root_dir = "/ds-mydata"
         case "designsafe.storage.frontera.scratch":
             root_dir = "/frontera-scratch"
+        case "designsafe.storage.frontera.work":
+            root_dir = "/frontera-work"
         case "designsafe.storage.community":
             root_dir = "/corral-repl/tacc/NHERI/community"
         case "designsafe.storage.published":


### PR DESCRIPTION
Adds support for the `designsafe.storage.frontera.work` system mounted at `/frontera-work` on the host VM.